### PR TITLE
feat: 日記の共有停止機能を追加

### DIFF
--- a/docs/project/firebase/ai-and-operations.md
+++ b/docs/project/firebase/ai-and-operations.md
@@ -27,7 +27,7 @@ snapshot metadataは`../firebase.md`を参照してください。
 - diary作成はStorage upload後にFirestoreへsetし、失敗時はupload済み画像の削除を試みます。AI生成画像も同じrollback対象です。
 - 編集は新画像upload → Firestore merge → 旧画像deleteです。Firestore失敗時は新画像をrollbackします。
 - 編集成功後の旧画像delete失敗はwarningとなり、孤児objectが残り得ます。
-- 削除はStorage → Firestoreの順で、後段失敗時はdocumentが削除済み画像を参照し得ます。
+- 削除は共有停止 → private Firestore document削除 → Storage画像整理の順です。共有停止失敗時は削除を中断し、Firestore削除後の画像整理失敗はwarningとして孤児objectを許容します。
 - diary作成後のmemory保存失敗は、作成済みdiaryの成功を取り消しません。
 - display nameとshared document更新はFirestore batchです。詳細は`../firestore/sharing.md`を参照します。
 - Storage、Firestore、AIを跨ぐtransactionはありません。

--- a/docs/project/firestore/diaries.md
+++ b/docs/project/firestore/diaries.md
@@ -8,6 +8,7 @@ path: `users/{uid}/diaries/{diaryId}`、client: `src/lib/service/diaryClient.ts`
 | ----------- | ----------------------------------- | ----------------------------------------- |
 | `id`        | `string`                            | document IDと同値                         |
 | `uid`       | `string`                            | owner UID                                 |
+| `shareId`   | `string`、optional                  | 現在有効な共有document ID                 |
 | `date`      | `Timestamp` on read                 | `Date`または`Timestamp`を書く             |
 | `title`     | `string`                            | AI生成、edit可能                          |
 | `content`   | `string`                            | 本文                                      |
@@ -18,7 +19,7 @@ path: `users/{uid}/diaries/{diaryId}`、client: `src/lib/service/diaryClient.ts`
 
 `DiaryImage`は`id`、`storagePath`、`downloadURL`、`width`、`height`、`contentType`です。型は`src/types/diary/diary.ts`を正本とします。
 
-現行edit flowは`createdAt`を渡さず値を維持し、`updatedAt`だけを更新します。日記カードはlegacy dataで`updatedAt`がない場合に`createdAt`を最終更新日時として表示します。
+現行edit flowは`createdAt`と`shareId`を渡さず値を維持し、`updatedAt`だけを更新します。日記カードはlegacy dataで`updatedAt`がない場合に`createdAt`を最終更新日時として表示します。
 
 ## Reads
 
@@ -35,6 +36,7 @@ path: `users/{uid}/diaries/{diaryId}`、client: `src/lib/service/diaryClient.ts`
 
 - add: `setDoc(users/{uid}/diaries/{id}, data)`。
 - update: `setDoc(..., { merge: true })`、delete: document `delete`。
+- 共有開始 / 停止は`SharedDiaryClient`がtransactionで`shareId`を設定 / 除去し、公開copyと同期します。
 - Storageとの順序と失敗挙動は`../firebase/ai-and-operations.md`を参照します。
 - callerはcreateDiaryの作成、homeの月取得、diariesの日取得・編集・削除です。
 - sidebarがpaging、`DiarySearchDialog`が全件取得を呼びます。

--- a/docs/project/firestore/favorites.md
+++ b/docs/project/firestore/favorites.md
@@ -11,12 +11,12 @@ path: `users/{uid}/favorites/{sharedDiaryId}`、client: `src/lib/service/favorit
 
 - document IDに共有日記IDを使い、同じユーザーによる重複登録を防ぎます。
 - UID、共有日記本文は保存しません。
-- 共有日記の削除に連動したcleanupはありません。
+- 共有日記の削除時に別userのfavoriteを直接cleanupしません。favorite ownerがsidebar一覧を取得した際、参照先が存在しない文書を自身の権限でbest-effort削除します。
 - `createdAt`を持たない既存文書のmigrationはなく、一覧queryの対象外です。
 
 ## Reads and writes
 
 - 共有日記ページは認証済みの場合だけID指定`getDoc`で登録状態を読みます。
 - 追加はtransactionで文書がない場合だけserver timestamp付きで作成し、解除は`deleteDoc`です。
-- sidebar一覧は`createdAt desc`で11件読み、10件とcursor、次pageの有無を返します。参照先の共有日記は最大10 IDの`in` queryで取得します。
+- sidebar一覧は`createdAt desc`で11件読み、10件とcursor、次pageの有無を返します。参照先の共有日記は最大10 IDの`in` queryで取得し、存在しないIDのfavoriteを削除してから有効な日記を10件まで補充します。cleanup失敗は有効な一覧表示を止めず、次回取得で再試行します。
 - Security Rulesはpath ownerだけにread / writeを許可します。

--- a/docs/project/firestore/sharing.md
+++ b/docs/project/firestore/sharing.md
@@ -9,8 +9,10 @@ path: `sharedDiaries/{shareId}`、client: `src/lib/service/sharedDiaryClient.ts`
 | `displayName` | `string`            | type上optional、legacy fallbackあり |
 | `sharedAt`    | `Timestamp` on read | publish時は`Date`                   |
 
-- `shareId`はsource `diary.id`と同じです。
-- publishは`setDoc`で同じIDを上書きします。
+- 新規`shareId`は`share-{uuid}`で生成し、source diaryのoptional `shareId`へ保存します。公開copyには管理用`shareId`を含めません。
+- publishはtransactionでsource diaryを読み、公開copyのsetとsource `shareId`の更新を同時に行います。共有中は同じIDを再利用し、停止後の再共有では新しいIDを発行します。
+- `shareId`を持たないlegacy diaryは`sharedDiaries/{diary.id}`の存在を確認し、既存URLを共有中として扱います。明示的な一括migrationはありません。
+- unpublishはtransactionで公開copyを削除し、source diaryの`shareId`を除去します。legacy公開copyも同じ操作で削除できます。
 - public pageはID指定`getDoc`で読みます。
 - profile更新は`where("uid", "==", uid)`で取得し、499件ずつbatch updateします。
 
@@ -19,12 +21,14 @@ path: `sharedDiaries/{shareId}`、client: `src/lib/service/sharedDiaryClient.ts`
 同期するもの:
 
 - publish時のDiary snapshot
+- publish / unpublish時のsource diary `shareId`
 - profile更新後の`displayName`
 
 同期しないもの:
 
-- source diaryの後続edit / delete
+- source diaryの後続edit
 - source image delete後のshared document cleanup
-- 明示的unpublish
+
+source diary削除時は、先にunpublishを完了してからprivate documentを削除します。unpublish失敗時はprivate documentの削除を中断します。favorite documentは別userのprivate dataであるため削除せず、参照先のないfavoriteは既存一覧で除外します。
 
 shared documentはsource diaryと継続同期されるviewではありません。

--- a/docs/project/firestore/sharing.md
+++ b/docs/project/firestore/sharing.md
@@ -29,6 +29,6 @@ path: `sharedDiaries/{shareId}`、client: `src/lib/service/sharedDiaryClient.ts`
 - source diaryの後続edit
 - source image delete後のshared document cleanup
 
-source diary削除時は、先にunpublishを完了してからprivate documentを削除します。unpublish失敗時はprivate documentの削除を中断します。favorite documentは別userのprivate dataであるため削除せず、参照先のないfavoriteは既存一覧で除外します。
+source diary削除時は、先にunpublishを完了してからprivate documentを削除します。unpublish失敗時はprivate documentの削除を中断します。共有者は別userのprivate favoriteを削除せず、favorite ownerがsidebar一覧を取得した際に参照先のない文書を自身の権限でbest-effort削除します。
 
 shared documentはsource diaryと継続同期されるviewではありません。

--- a/src/features/diaries/components/DiaryDeleteDialog.test.tsx
+++ b/src/features/diaries/components/DiaryDeleteDialog.test.tsx
@@ -31,7 +31,7 @@ describe("DiaryDeleteDialog", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "「夏の思い出」を削除します。この操作は取り消せません。",
+        "「夏の思い出」を削除します。共有中の場合は共有も停止されます。この操作は取り消せません。",
       ),
     ).toBeInTheDocument();
   });

--- a/src/features/diaries/components/DiaryPreviewCard.tsx
+++ b/src/features/diaries/components/DiaryPreviewCard.tsx
@@ -36,6 +36,7 @@ import {
   Share2,
   Tag,
   Trash2,
+  Unlink,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -48,6 +49,7 @@ import { useShareDiary } from "../hooks/useShareDiary";
 import { DiaryDeleteDialog } from "./DiaryDeleteDialog";
 import { DiaryEditDialog } from "./DiaryEditDialog";
 import { DiaryImageGrid } from "./DiaryImageGrid";
+import { DiaryUnshareDialog } from "./DiaryUnshareDialog";
 
 type DiaryPreviewCardProps = {
   diary: Diary;
@@ -62,8 +64,19 @@ export const DiaryPreviewCard = ({
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const { isSharing, copyShareLink, shareToLine, shareToX } =
-    useShareDiary(diary);
+  const [isUnshareDialogOpen, setIsUnshareDialogOpen] = useState(false);
+  const {
+    isSharing,
+    isUnsharing,
+    isShared,
+    isCheckingShareStatus,
+    hasShareStatusError,
+    checkShareStatus,
+    unshareDiary,
+    copyShareLink,
+    shareToLine,
+    shareToX,
+  } = useShareDiary(diary);
   const { isUpdating, isDeleting, updateDiary, deleteDiary } =
     useDiaryPreviewActions({
       diary,
@@ -95,6 +108,14 @@ export const DiaryPreviewCard = ({
     }
   };
 
+  const handleUnshare = async () => {
+    const isUnshared = await unshareDiary();
+
+    if (isUnshared) {
+      setIsUnshareDialogOpen(false);
+    }
+  };
+
   const handleEditSelect = useCallback(() => {
     setIsMenuOpen(false);
     requestAnimationFrame(() => setIsEditDialogOpen(true));
@@ -103,6 +124,11 @@ export const DiaryPreviewCard = ({
   const handleDeleteSelect = useCallback(() => {
     setIsMenuOpen(false);
     requestAnimationFrame(() => setIsDeleteDialogOpen(true));
+  }, []);
+
+  const handleUnshareSelect = useCallback(() => {
+    setIsMenuOpen(false);
+    requestAnimationFrame(() => setIsUnshareDialogOpen(true));
   }, []);
 
   return (
@@ -139,7 +165,13 @@ export const DiaryPreviewCard = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-fit p-2">
-                <DropdownMenuSub>
+                <DropdownMenuSub
+                  onOpenChange={(open) => {
+                    if (open) {
+                      void checkShareStatus();
+                    }
+                  }}
+                >
                   <DropdownMenuSubTrigger
                     className="justify-start"
                     disabled={isSharing}
@@ -190,6 +222,39 @@ export const DiaryPreviewCard = ({
                         <XIcon />
                         Xで共有
                       </DropdownMenuItem>
+                      {isCheckingShareStatus && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem disabled>
+                            <Loader2 className="animate-spin" />
+                            共有状態を確認中...
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {hasShareStatusError && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem disabled>
+                            共有状態を確認できません
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {isShared && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="justify-start"
+                            variant="destructive"
+                            onSelect={(event) => {
+                              event.preventDefault();
+                              handleUnshareSelect();
+                            }}
+                          >
+                            <Unlink />
+                            共有を停止
+                          </DropdownMenuItem>
+                        </>
+                      )}
                     </DropdownMenuSubContent>
                   </DropdownMenuPortal>
                 </DropdownMenuSub>
@@ -256,6 +321,13 @@ export const DiaryPreviewCard = ({
         isDeleting={isDeleting}
         onOpenChange={setIsDeleteDialogOpen}
         onDelete={handleDelete}
+      />
+      <DiaryUnshareDialog
+        title={diary.title}
+        isOpen={isUnshareDialogOpen}
+        isUnsharing={isUnsharing}
+        onOpenChange={setIsUnshareDialogOpen}
+        onUnshare={handleUnshare}
       />
     </>
   );

--- a/src/features/diaries/components/DiaryUnshareDialog.test.tsx
+++ b/src/features/diaries/components/DiaryUnshareDialog.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DiaryUnshareDialog } from "./DiaryUnshareDialog";
+
+const renderDialog = (isUnsharing = false) => {
+  const onOpenChange = vi.fn();
+  const onUnshare = vi.fn().mockResolvedValue(undefined);
+  const user = userEvent.setup();
+
+  render(
+    <DiaryUnshareDialog
+      title="夏の思い出"
+      isOpen
+      isUnsharing={isUnsharing}
+      onOpenChange={onOpenChange}
+      onUnshare={onUnshare}
+    />,
+  );
+
+  return { onOpenChange, onUnshare, user };
+};
+
+describe("DiaryUnshareDialog", () => {
+  it("現在のリンクが無効になり、再共有で新しいリンクになると説明する", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: "共有を停止しますか？" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "「夏の思い出」の現在の共有リンクを無効にします。再共有すると新しいリンクが発行されます。",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("共有停止を1回実行する", async () => {
+    const { onUnshare, user } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "共有を停止する" }));
+
+    expect(onUnshare).toHaveBeenCalledOnce();
+  });
+
+  it("停止中は操作を無効化し、close要求を無視する", async () => {
+    const { onOpenChange, user } = renderDialog(true);
+
+    expect(screen.getByRole("button", { name: "キャンセル" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "停止中..." })).toBeDisabled();
+
+    await user.keyboard("{Escape}");
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/diaries/components/DiaryUnshareDialog.tsx
+++ b/src/features/diaries/components/DiaryUnshareDialog.tsx
@@ -8,23 +8,23 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-type DiaryDeleteDialogProps = {
+type DiaryUnshareDialogProps = {
   title: string;
   isOpen: boolean;
-  isDeleting: boolean;
+  isUnsharing: boolean;
   onOpenChange: (open: boolean) => void;
-  onDelete: () => Promise<void>;
+  onUnshare: () => Promise<void>;
 };
 
-export const DiaryDeleteDialog = ({
+export const DiaryUnshareDialog = ({
   title,
   isOpen,
-  isDeleting,
+  isUnsharing,
   onOpenChange,
-  onDelete,
-}: DiaryDeleteDialogProps) => {
+  onUnshare,
+}: DiaryUnshareDialogProps) => {
   const handleOpenChange = (open: boolean) => {
-    if (isDeleting) return;
+    if (isUnsharing) return;
 
     onOpenChange(open);
   };
@@ -33,10 +33,10 @@ export const DiaryDeleteDialog = ({
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>日記を削除しますか？</DialogTitle>
+          <DialogTitle>共有を停止しますか？</DialogTitle>
           <DialogDescription>
             「{title}
-            」を削除します。共有中の場合は共有も停止されます。この操作は取り消せません。
+            」の現在の共有リンクを無効にします。再共有すると新しいリンクが発行されます。
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-row gap-2 sm:gap-0">
@@ -45,7 +45,7 @@ export const DiaryDeleteDialog = ({
             variant="outline"
             className="flex-1 sm:flex-none"
             onClick={() => handleOpenChange(false)}
-            disabled={isDeleting}
+            disabled={isUnsharing}
           >
             キャンセル
           </Button>
@@ -53,10 +53,10 @@ export const DiaryDeleteDialog = ({
             type="button"
             variant="destructive"
             className="flex-1 sm:flex-none"
-            onClick={onDelete}
-            disabled={isDeleting}
+            onClick={onUnshare}
+            disabled={isUnsharing}
           >
-            {isDeleting ? "削除中..." : "削除する"}
+            {isUnsharing ? "停止中..." : "共有を停止する"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/diaries/components/DiaryUnshareDialog.tsx
+++ b/src/features/diaries/components/DiaryUnshareDialog.tsx
@@ -36,7 +36,7 @@ export const DiaryUnshareDialog = ({
           <DialogTitle>共有を停止しますか？</DialogTitle>
           <DialogDescription>
             「{title}
-            」の現在の共有リンクを無効にします。再共有すると新しいリンクが発行されます。
+            」の現在の共有リンクを無効にします。
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="flex-row gap-2 sm:gap-0">

--- a/src/features/diaries/hooks/useDiaryPreviewActions.test.ts
+++ b/src/features/diaries/hooks/useDiaryPreviewActions.test.ts
@@ -1,0 +1,144 @@
+import { DiaryClient } from "@/lib/service/diaryClient";
+import { DiaryImageClient } from "@/lib/service/diaryImageClient";
+import { SharedDiaryClient } from "@/lib/service/sharedDiaryClient";
+import type { Diary } from "@/types/diary/diary";
+import { act, renderHook } from "@testing-library/react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDiaryPreviewActions } from "./useDiaryPreviewActions";
+
+vi.mock("@/lib/service/diaryClient", () => ({
+  DiaryClient: {
+    delete: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/service/diaryImageClient", () => ({
+  DiaryImageClient: {
+    deleteMany: vi.fn(),
+    upload: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/service/sharedDiaryClient", () => ({
+  SharedDiaryClient: {
+    unpublish: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/diarySearchStore", () => ({
+  invalidateDiarySearchCache: vi.fn(),
+}));
+
+vi.mock("@/stores/diaryRefreshStore", () => ({
+  requestDiaryRefresh: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const diary = {
+  id: "diary-1",
+  uid: "user-1",
+  title: "夏の思い出",
+  content: "海へ行きました。",
+  tags: [],
+  images: [{ id: "image-1" }],
+  date: {},
+  createdAt: {},
+} as unknown as Diary;
+
+const unpublishMock = vi.mocked(SharedDiaryClient.unpublish);
+const deleteDiaryMock = vi.mocked(DiaryClient.delete);
+const deleteImagesMock = vi.mocked(DiaryImageClient.deleteMany);
+const toastErrorMock = vi.mocked(toast.error);
+const toastWarningMock = vi.mocked(toast.warning);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  unpublishMock.mockResolvedValue({ wasShared: true });
+  deleteDiaryMock.mockResolvedValue(undefined);
+  deleteImagesMock.mockResolvedValue(undefined);
+});
+
+describe("useDiaryPreviewActions deleteDiary", () => {
+  it("共有停止、日記削除、画像整理の順に実行する", async () => {
+    const onCompleted = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() =>
+      useDiaryPreviewActions({ diary, onCompleted }),
+    );
+
+    let isDeleted = false;
+    await act(async () => {
+      isDeleted = await result.current.deleteDiary();
+    });
+
+    expect(isDeleted).toBe(true);
+    expect(unpublishMock).toHaveBeenCalledWith(diary);
+    expect(deleteDiaryMock).toHaveBeenCalledWith("user-1", "diary-1");
+    expect(deleteImagesMock).toHaveBeenCalledWith(diary.images);
+    expect(unpublishMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteDiaryMock.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(deleteDiaryMock.mock.invocationCallOrder[0]).toBeLessThan(
+      deleteImagesMock.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it("共有停止に失敗した場合は日記と画像を削除しない", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    unpublishMock.mockRejectedValue(new Error("unpublish failed"));
+    const { result } = renderHook(() =>
+      useDiaryPreviewActions({ diary, onCompleted: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.deleteDiary();
+    });
+
+    expect(deleteDiaryMock).not.toHaveBeenCalled();
+    expect(deleteImagesMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith("日記の削除に失敗しました");
+  });
+
+  it("共有停止後に日記削除が失敗した場合は部分成功を通知する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    deleteDiaryMock.mockRejectedValue(new Error("delete failed"));
+    const { result } = renderHook(() =>
+      useDiaryPreviewActions({ diary, onCompleted: vi.fn() }),
+    );
+
+    await act(async () => {
+      await result.current.deleteDiary();
+    });
+
+    expect(deleteImagesMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "共有は停止しましたが、日記の削除に失敗しました",
+    );
+  });
+
+  it("日記削除後の画像整理失敗は警告し、削除成功として扱う", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    deleteImagesMock.mockRejectedValue(new Error("image delete failed"));
+    const { result } = renderHook(() =>
+      useDiaryPreviewActions({ diary, onCompleted: vi.fn() }),
+    );
+
+    let isDeleted = false;
+    await act(async () => {
+      isDeleted = await result.current.deleteDiary();
+    });
+
+    expect(isDeleted).toBe(true);
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      "日記を削除しましたが、画像の整理に失敗しました",
+    );
+  });
+});

--- a/src/features/diaries/hooks/useDiaryPreviewActions.ts
+++ b/src/features/diaries/hooks/useDiaryPreviewActions.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 
 import { DiaryClient } from "@/lib/service/diaryClient";
 import { DiaryImageClient } from "@/lib/service/diaryImageClient";
+import { SharedDiaryClient } from "@/lib/service/sharedDiaryClient";
 import type { Diary, DiaryImage } from "@/types/diary/diary";
 import { Timestamp } from "firebase/firestore";
 import { invalidateDiarySearchCache } from "@/stores/diarySearchStore";
@@ -95,22 +96,38 @@ export const useDiaryPreviewActions = ({
 
   const deleteDiary = useCallback(async () => {
     setIsDeleting(true);
+    let wasShared = false;
+
     try {
-      await DiaryImageClient.deleteMany(diary.images ?? []);
+      const unshareResult = await SharedDiaryClient.unpublish(diary);
+      wasShared = unshareResult.wasShared;
       await DiaryClient.delete(diary.uid, diary.id);
       invalidateDiarySearchCache();
       requestDiaryRefresh();
       await onCompleted();
-      toast.success("日記を削除しました");
-      return true;
     } catch (error) {
       console.error("Failed to delete diary", error);
-      toast.error("日記の削除に失敗しました");
+      toast.error(
+        wasShared
+          ? "共有は停止しましたが、日記の削除に失敗しました"
+          : "日記の削除に失敗しました",
+      );
+      setIsDeleting(false);
       return false;
+    }
+
+    try {
+      await DiaryImageClient.deleteMany(diary.images ?? []);
+      toast.success("日記を削除しました");
+    } catch (error) {
+      console.error("Failed to delete diary images", error);
+      toast.warning("日記を削除しましたが、画像の整理に失敗しました");
     } finally {
       setIsDeleting(false);
     }
-  }, [diary.id, diary.images, diary.uid, onCompleted]);
+
+    return true;
+  }, [diary, onCompleted]);
 
   return {
     isUpdating,

--- a/src/features/diaries/hooks/useShareDiary.test.ts
+++ b/src/features/diaries/hooks/useShareDiary.test.ts
@@ -16,7 +16,9 @@ vi.mock("@/contexts/LocalUserContext", () => ({
 
 vi.mock("@/lib/service/sharedDiaryClient", () => ({
   SharedDiaryClient: {
+    getActiveShareId: vi.fn(),
     publish: vi.fn(),
+    unpublish: vi.fn(),
   },
 }));
 
@@ -38,6 +40,8 @@ const diary: Diary = {
 };
 
 const publishMock = vi.mocked(SharedDiaryClient.publish);
+const getActiveShareIdMock = vi.mocked(SharedDiaryClient.getActiveShareId);
+const unpublishMock = vi.mocked(SharedDiaryClient.unpublish);
 const toastSuccessMock = vi.mocked(toast.success);
 const toastErrorMock = vi.mocked(toast.error);
 
@@ -54,6 +58,51 @@ const createPopup = () => {
 };
 
 describe("useShareDiary", () => {
+  it("共有メニューを開いたときに共有状態を取得する", async () => {
+    getActiveShareIdMock.mockResolvedValue("share-active");
+    const { result } = renderHook(() => useShareDiary(diary));
+
+    await act(async () => {
+      await result.current.checkShareStatus();
+    });
+
+    expect(getActiveShareIdMock).toHaveBeenCalledWith(diary);
+    expect(result.current.isShared).toBe(true);
+    expect(result.current.isCheckingShareStatus).toBe(false);
+  });
+
+  it("共有停止後に状態を更新して成功を通知する", async () => {
+    getActiveShareIdMock.mockResolvedValue("share-active");
+    unpublishMock.mockResolvedValue({ wasShared: true });
+    const { result } = renderHook(() => useShareDiary(diary));
+
+    await act(async () => {
+      await result.current.checkShareStatus();
+      await result.current.unshareDiary();
+    });
+
+    expect(unpublishMock).toHaveBeenCalledWith(diary);
+    expect(result.current.isShared).toBe(false);
+    expect(toastSuccessMock).toHaveBeenCalledWith("共有を停止しました");
+  });
+
+  it("共有停止に失敗した場合は共有中の状態を維持する", async () => {
+    getActiveShareIdMock.mockResolvedValue("share-active");
+    unpublishMock.mockRejectedValue(new Error("unpublish failed"));
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { result } = renderHook(() => useShareDiary(diary));
+
+    await act(async () => {
+      await result.current.checkShareStatus();
+    });
+    await act(async () => {
+      await result.current.unshareDiary();
+    });
+
+    expect(result.current.isShared).toBe(true);
+    expect(toastErrorMock).toHaveBeenCalledWith("共有の停止に失敗しました");
+  });
+
   it("公開した共有URLをclipboardへコピーし、処理中状態を更新する", async () => {
     let resolvePublish: ((value: { shareId: string }) => void) | undefined;
     const publishPromise = new Promise<{ shareId: string }>((resolve) => {

--- a/src/features/diaries/hooks/useShareDiary.ts
+++ b/src/features/diaries/hooks/useShareDiary.ts
@@ -5,6 +5,8 @@ import type { Diary } from "@/types/diary/diary";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
+type ShareStatus = "idle" | "loading" | "shared" | "not-shared" | "error";
+
 const copyToClipboard = async (text: string) => {
   if (!navigator.clipboard?.writeText) {
     return false;
@@ -29,15 +31,50 @@ const buildXShareUrl = (shareUrl: string, title: string) =>
 
 export const useShareDiary = (diary: Diary) => {
   const [isSharing, setIsSharing] = useState(false);
+  const [isUnsharing, setIsUnsharing] = useState(false);
+  const [shareStatus, setShareStatus] = useState<ShareStatus>("idle");
   const { localUser } = useLocalUser();
+
+  const checkShareStatus = useCallback(async () => {
+    if (shareStatus !== "idle" && shareStatus !== "error") {
+      return;
+    }
+
+    setShareStatus("loading");
+    try {
+      const shareId = await SharedDiaryClient.getActiveShareId(diary);
+      setShareStatus(shareId ? "shared" : "not-shared");
+    } catch (error) {
+      console.error("Failed to check diary share status", error);
+      setShareStatus("error");
+      toast.error("共有状態の確認に失敗しました");
+    }
+  }, [diary, shareStatus]);
 
   const publishShareUrl = useCallback(async () => {
     const { shareId } = await SharedDiaryClient.publish(
       diary,
       localUser.displayName,
     );
+    setShareStatus("shared");
     return buildShareUrl(shareId);
   }, [diary, localUser.displayName]);
+
+  const unshareDiary = useCallback(async () => {
+    setIsUnsharing(true);
+    try {
+      await SharedDiaryClient.unpublish(diary);
+      setShareStatus("not-shared");
+      toast.success("共有を停止しました");
+      return true;
+    } catch (error) {
+      console.error("Failed to unshare diary", error);
+      toast.error("共有の停止に失敗しました");
+      return false;
+    } finally {
+      setIsUnsharing(false);
+    }
+  }, [diary]);
 
   const copyShareLink = useCallback(async () => {
     setIsSharing(true);
@@ -112,6 +149,12 @@ export const useShareDiary = (diary: Diary) => {
 
   return {
     isSharing,
+    isUnsharing,
+    isShared: shareStatus === "shared",
+    isCheckingShareStatus: shareStatus === "loading",
+    hasShareStatusError: shareStatus === "error",
+    checkShareStatus,
+    unshareDiary,
     copyShareLink,
     shareToLine,
     shareToX,

--- a/src/features/sidebar/hooks/useFetchFavoriteDiaries.test.ts
+++ b/src/features/sidebar/hooks/useFetchFavoriteDiaries.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/contexts/LocalUserContext", () => ({
 
 vi.mock("@/lib/service/favoriteClient", () => ({
   FavoriteClient: {
+    delete: vi.fn(),
     getByUidPaged: vi.fn(),
   },
 }));
@@ -40,6 +41,7 @@ vi.mock("sonner", () => ({
 
 const useLocalUserMock = vi.mocked(useLocalUser);
 const getByUidPagedMock = vi.mocked(FavoriteClient.getByUidPaged);
+const deleteFavoriteMock = vi.mocked(FavoriteClient.delete);
 const getByShareIdsMock = vi.mocked(SharedDiaryClient.getByShareIds);
 const useFavoriteRefreshStoreMock = vi.mocked(useFavoriteRefreshStore);
 const toastErrorMock = vi.mocked(toast.error);
@@ -75,6 +77,7 @@ beforeEach(() => {
     selector({ revision: refreshRevision, requestRefresh: vi.fn() }),
   );
   getByUidPagedMock.mockResolvedValue(createPage([]));
+  deleteFavoriteMock.mockResolvedValue(undefined);
   getByShareIdsMock.mockResolvedValue([]);
 });
 
@@ -134,6 +137,26 @@ describe("useFetchFavoriteDiaries", () => {
       result.current.favoriteDiaries[result.current.favoriteDiaries.length - 1]
         ?.sharedDiaryId,
     ).toBe("shared-10");
+    expect(deleteFavoriteMock).toHaveBeenCalledWith("user-1", "shared-9");
+  });
+
+  it("無効なお気に入りの削除に失敗しても有効な一覧を表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    getByUidPagedMock.mockResolvedValue(
+      createPage(["shared-active", "shared-stale"]),
+    );
+    getByShareIdsMock.mockResolvedValue([createResolvedDiary("shared-active")]);
+    deleteFavoriteMock.mockRejectedValue(new Error("delete failed"));
+
+    const { result } = renderHook(() => useFetchFavoriteDiaries(true));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.favoriteDiaries).toEqual([
+      { sharedDiaryId: "shared-active", title: "shared-active-title" },
+    ]);
+    expect(deleteFavoriteMock).toHaveBeenCalledWith("user-1", "shared-stale");
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
   it("さらに10件を既存一覧へ追加する", async () => {

--- a/src/features/sidebar/hooks/useFetchFavoriteDiaries.ts
+++ b/src/features/sidebar/hooks/useFetchFavoriteDiaries.ts
@@ -50,6 +50,24 @@ const fetchResolvedFavoritePage = async (
       resolvedDiaries.map(({ sharedDiaryId, diary }) => [sharedDiaryId, diary]),
     );
 
+    const staleFavoriteIds = page.favorites
+      .map((favorite) => favorite.sharedDiaryId)
+      .filter((sharedDiaryId) => !diaryById.has(sharedDiaryId));
+    const cleanupResults = await Promise.allSettled(
+      staleFavoriteIds.map((sharedDiaryId) =>
+        FavoriteClient.delete(uid, sharedDiaryId),
+      ),
+    );
+
+    cleanupResults.forEach((result, index) => {
+      if (result.status === "rejected") {
+        console.error(
+          `Failed to delete stale favorite: ${staleFavoriteIds[index]}`,
+          result.reason,
+        );
+      }
+    });
+
     page.favorites.forEach(({ sharedDiaryId }) => {
       const diary = diaryById.get(sharedDiaryId);
       if (diary) {

--- a/src/lib/generateId.ts
+++ b/src/lib/generateId.ts
@@ -8,6 +8,10 @@ export function generateDiaryImageId() {
   return `diary-image-${uuidv4()}`;
 }
 
+export function generateShareId() {
+  return `share-${uuidv4()}`;
+}
+
 export function generateMemoryFactId() {
   return `memory-fact-${uuidv4()}`;
 }

--- a/src/lib/service/sharedDiaryClient.test.ts
+++ b/src/lib/service/sharedDiaryClient.test.ts
@@ -1,14 +1,20 @@
+import type { Diary } from "@/types/diary/diary";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SharedDiaryClient } from "./sharedDiaryClient";
 
 const firestoreMocks = vi.hoisted(() => ({
   collection: vi.fn(),
+  deleteField: vi.fn(),
   doc: vi.fn(),
   documentId: vi.fn(),
   getDoc: vi.fn(),
   getDocs: vi.fn(),
   query: vi.fn(),
-  setDoc: vi.fn(),
+  runTransaction: vi.fn(),
+  transactionDelete: vi.fn(),
+  transactionGet: vi.fn(),
+  transactionSet: vi.fn(),
+  transactionUpdate: vi.fn(),
   where: vi.fn(),
 }));
 
@@ -16,20 +22,170 @@ vi.mock("@/firebase/firebase", () => ({
   db: { name: "test-db" },
 }));
 
+vi.mock("@/lib/generateId", () => ({
+  generateShareId: () => "share-new",
+}));
+
 vi.mock("firebase/firestore", () => ({
   collection: firestoreMocks.collection,
+  deleteField: firestoreMocks.deleteField,
   doc: firestoreMocks.doc,
   documentId: firestoreMocks.documentId,
   getDoc: firestoreMocks.getDoc,
   getDocs: firestoreMocks.getDocs,
   query: firestoreMocks.query,
-  setDoc: firestoreMocks.setDoc,
+  runTransaction: firestoreMocks.runTransaction,
   where: firestoreMocks.where,
 }));
 
+const diary = {
+  id: "diary-1",
+  uid: "user-1",
+  title: "夏の思い出",
+  content: "海へ行きました。",
+  tags: [],
+  date: { seconds: 1 },
+  createdAt: { seconds: 2 },
+} as unknown as Diary;
+
+const createSnapshot = (
+  data?: Record<string, unknown>,
+): { exists: () => boolean; data: () => Record<string, unknown> } => ({
+  exists: () => data !== undefined,
+  data: () => data ?? {},
+});
+
 beforeEach(() => {
+  vi.clearAllMocks();
+  firestoreMocks.doc.mockImplementation((...segments: unknown[]) => ({
+    segments: segments.slice(1),
+  }));
+  firestoreMocks.deleteField.mockReturnValue("delete-field");
   firestoreMocks.documentId.mockReturnValue("document-id");
   firestoreMocks.getDocs.mockResolvedValue({ docs: [] });
+  firestoreMocks.runTransaction.mockImplementation(
+    async (_db, callback: (transaction: unknown) => unknown) =>
+      callback({
+        delete: firestoreMocks.transactionDelete,
+        get: firestoreMocks.transactionGet,
+        set: firestoreMocks.transactionSet,
+        update: firestoreMocks.transactionUpdate,
+      }),
+  );
+});
+
+describe("SharedDiaryClient.publish", () => {
+  it("新しい共有IDで公開コピーと元日記を同時に更新する", async () => {
+    firestoreMocks.transactionGet
+      .mockResolvedValueOnce(createSnapshot(diary))
+      .mockResolvedValueOnce(createSnapshot());
+
+    await expect(
+      SharedDiaryClient.publish(diary, "テストユーザー"),
+    ).resolves.toEqual({ shareId: "share-new" });
+
+    expect(firestoreMocks.transactionSet).toHaveBeenCalledWith(
+      expect.objectContaining({ segments: ["sharedDiaries", "share-new"] }),
+      expect.objectContaining({
+        id: "diary-1",
+        uid: "user-1",
+        displayName: "テストユーザー",
+        sharedAt: expect.any(Date),
+      }),
+    );
+    expect(firestoreMocks.transactionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        segments: ["users", "user-1", "diaries", "diary-1"],
+      }),
+      { shareId: "share-new" },
+    );
+  });
+
+  it("共有中は既存IDを再利用し、管理用shareIdを公開しない", async () => {
+    firestoreMocks.transactionGet.mockResolvedValueOnce(
+      createSnapshot({ ...diary, shareId: "share-active" }),
+    );
+
+    await expect(SharedDiaryClient.publish(diary)).resolves.toEqual({
+      shareId: "share-active",
+    });
+
+    const publicDiary = firestoreMocks.transactionSet.mock.calls[0]?.[1];
+    expect(publicDiary).not.toHaveProperty("shareId");
+    expect(firestoreMocks.transactionGet).toHaveBeenCalledOnce();
+  });
+
+  it("旧形式の公開コピーがあれば日記IDを引き続き使用する", async () => {
+    firestoreMocks.transactionGet
+      .mockResolvedValueOnce(createSnapshot(diary))
+      .mockResolvedValueOnce(createSnapshot({ ...diary, sharedAt: {} }));
+
+    await expect(SharedDiaryClient.publish(diary)).resolves.toEqual({
+      shareId: "diary-1",
+    });
+  });
+});
+
+describe("SharedDiaryClient share status and unpublish", () => {
+  it("保存済みshareIdの公開コピーが存在する場合だけ共有中と判定する", async () => {
+    firestoreMocks.getDoc.mockResolvedValue(createSnapshot({ uid: "user-1" }));
+
+    await expect(
+      SharedDiaryClient.getActiveShareId({
+        id: diary.id,
+        uid: diary.uid,
+        shareId: "share-active",
+      }),
+    ).resolves.toBe("share-active");
+    expect(firestoreMocks.doc).toHaveBeenLastCalledWith(
+      { name: "test-db" },
+      "sharedDiaries",
+      "share-active",
+    );
+  });
+
+  it("shareIdがない既存日記では従来の日記IDを確認する", async () => {
+    firestoreMocks.getDoc.mockResolvedValue(createSnapshot({ uid: "user-1" }));
+
+    await expect(SharedDiaryClient.getActiveShareId(diary)).resolves.toBe(
+      "diary-1",
+    );
+  });
+
+  it("公開コピーを削除して元日記のshareIdを除去する", async () => {
+    firestoreMocks.transactionGet
+      .mockResolvedValueOnce(
+        createSnapshot({ ...diary, shareId: "share-active" }),
+      )
+      .mockResolvedValueOnce(createSnapshot({ uid: "user-1" }));
+
+    await expect(SharedDiaryClient.unpublish(diary)).resolves.toEqual({
+      wasShared: true,
+    });
+    expect(firestoreMocks.transactionDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ segments: ["sharedDiaries", "share-active"] }),
+    );
+    expect(firestoreMocks.transactionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        segments: ["users", "user-1", "diaries", "diary-1"],
+      }),
+      { shareId: "delete-field" },
+    );
+  });
+
+  it("旧形式の公開コピーも削除できる", async () => {
+    firestoreMocks.transactionGet
+      .mockResolvedValueOnce(createSnapshot(diary))
+      .mockResolvedValueOnce(createSnapshot({ uid: "user-1" }));
+
+    await expect(SharedDiaryClient.unpublish(diary)).resolves.toEqual({
+      wasShared: true,
+    });
+    expect(firestoreMocks.transactionDelete).toHaveBeenCalledWith(
+      expect.objectContaining({ segments: ["sharedDiaries", "diary-1"] }),
+    );
+    expect(firestoreMocks.transactionUpdate).not.toHaveBeenCalled();
+  });
 });
 
 describe("SharedDiaryClient.getByShareIds", () => {

--- a/src/lib/service/sharedDiaryClient.ts
+++ b/src/lib/service/sharedDiaryClient.ts
@@ -1,14 +1,16 @@
 import { db } from "@/firebase/firebase";
 import { normalizeDisplayName } from "@/constants/userProfile";
+import { generateShareId } from "@/lib/generateId";
 import type { Diary } from "@/types/diary/diary";
 import {
   collection,
+  deleteField,
   doc,
   documentId,
   getDoc,
   getDocs,
   query,
-  setDoc,
+  runTransaction,
   where,
 } from "firebase/firestore";
 
@@ -16,9 +18,42 @@ type ShareResult = {
   shareId: string;
 };
 
+export type UnshareResult = {
+  wasShared: boolean;
+};
+
 export type SharedDiaryResult<T> = {
   sharedDiaryId: string;
   diary: T;
+};
+
+const validateDiaryIdentity = (diary: Pick<Diary, "id" | "uid">) => {
+  if (!diary.uid) {
+    throw new Error("Diary must contain a 'uid' field to share.");
+  }
+  if (!diary.id) {
+    throw new Error("Diary must contain an 'id' field to share.");
+  }
+};
+
+const getStoredShareId = (data: Record<string, unknown>) => {
+  if (data.shareId === undefined) {
+    return null;
+  }
+  if (typeof data.shareId !== "string" || !data.shareId) {
+    throw new Error("Diary contains an invalid 'shareId' field.");
+  }
+
+  return data.shareId;
+};
+
+const assertSharedDiaryOwner = (
+  data: Record<string, unknown>,
+  expectedUid: string,
+) => {
+  if (data.uid !== expectedUid) {
+    throw new Error("Shared diary owner does not match the source diary.");
+  }
 };
 
 export class SharedDiaryClient {
@@ -26,22 +61,118 @@ export class SharedDiaryClient {
     diary: Diary,
     displayName?: string | null,
   ): Promise<ShareResult> {
-    if (!diary.uid) {
-      throw new Error("Diary must contain a 'uid' field to share.");
-    }
-    if (!diary.id) {
-      throw new Error("Diary must contain an 'id' field to share.");
-    }
+    validateDiaryIdentity(diary);
 
-    const shareId = diary.id;
-    const sharedDiaryRef = doc(db, "sharedDiaries", shareId);
-    await setDoc(sharedDiaryRef, {
-      ...diary,
-      displayName: normalizeDisplayName(displayName),
-      sharedAt: new Date(),
+    const sourceDiaryRef = doc(db, "users", diary.uid, "diaries", diary.id);
+    const legacySharedDiaryRef = doc(db, "sharedDiaries", diary.id);
+    const nextShareId = generateShareId();
+
+    const shareId = await runTransaction(db, async (transaction) => {
+      const sourceDiarySnapshot = await transaction.get(sourceDiaryRef);
+
+      if (!sourceDiarySnapshot.exists()) {
+        throw new Error("Source diary does not exist.");
+      }
+
+      const sourceDiary = sourceDiarySnapshot.data() as Record<string, unknown>;
+      assertSharedDiaryOwner(sourceDiary, diary.uid);
+
+      const storedShareId = getStoredShareId(sourceDiary);
+      let resolvedShareId = storedShareId;
+
+      if (!resolvedShareId) {
+        const legacySharedDiarySnapshot =
+          await transaction.get(legacySharedDiaryRef);
+
+        if (legacySharedDiarySnapshot.exists()) {
+          assertSharedDiaryOwner(
+            legacySharedDiarySnapshot.data() as Record<string, unknown>,
+            diary.uid,
+          );
+          resolvedShareId = diary.id;
+        } else {
+          resolvedShareId = nextShareId;
+        }
+      }
+
+      const publicDiary = { ...sourceDiary };
+      delete publicDiary.shareId;
+      const sharedDiaryRef = doc(db, "sharedDiaries", resolvedShareId);
+
+      transaction.set(sharedDiaryRef, {
+        ...publicDiary,
+        displayName: normalizeDisplayName(displayName),
+        sharedAt: new Date(),
+      });
+      transaction.update(sourceDiaryRef, { shareId: resolvedShareId });
+
+      return resolvedShareId;
     });
 
     return { shareId };
+  }
+
+  static async getActiveShareId(
+    diary: Pick<Diary, "id" | "uid" | "shareId">,
+  ): Promise<string | null> {
+    validateDiaryIdentity(diary);
+
+    const shareId = diary.shareId ?? diary.id;
+    const snapshot = await getDoc(doc(db, "sharedDiaries", shareId));
+
+    if (!snapshot.exists()) {
+      return null;
+    }
+
+    assertSharedDiaryOwner(
+      snapshot.data() as Record<string, unknown>,
+      diary.uid,
+    );
+    return shareId;
+  }
+
+  static async unpublish(
+    diary: Pick<Diary, "id" | "uid">,
+  ): Promise<UnshareResult> {
+    validateDiaryIdentity(diary);
+
+    const sourceDiaryRef = doc(db, "users", diary.uid, "diaries", diary.id);
+    const legacySharedDiaryRef = doc(db, "sharedDiaries", diary.id);
+
+    return runTransaction(db, async (transaction) => {
+      const sourceDiarySnapshot = await transaction.get(sourceDiaryRef);
+
+      if (!sourceDiarySnapshot.exists()) {
+        throw new Error("Source diary does not exist.");
+      }
+
+      const sourceDiary = sourceDiarySnapshot.data() as Record<string, unknown>;
+      assertSharedDiaryOwner(sourceDiary, diary.uid);
+
+      const storedShareId = getStoredShareId(sourceDiary);
+      const sharedDiaryRef = storedShareId
+        ? doc(db, "sharedDiaries", storedShareId)
+        : legacySharedDiaryRef;
+      const sharedDiarySnapshot = await transaction.get(sharedDiaryRef);
+
+      if (!sharedDiarySnapshot.exists()) {
+        if (storedShareId) {
+          transaction.update(sourceDiaryRef, { shareId: deleteField() });
+        }
+        return { wasShared: false };
+      }
+
+      assertSharedDiaryOwner(
+        sharedDiarySnapshot.data() as Record<string, unknown>,
+        diary.uid,
+      );
+      transaction.delete(sharedDiaryRef);
+      if (storedShareId) {
+        transaction.update(sourceDiaryRef, { shareId: deleteField() });
+      }
+
+      return { wasShared: true };
+    });
   }
 
   static async getByShareId<T extends Record<string, unknown>>(

--- a/src/types/diary/diary.ts
+++ b/src/types/diary/diary.ts
@@ -17,6 +17,7 @@ export type DiaryImage = {
 export type Diary = {
   id: string;
   uid: string;
+  shareId?: string;
   date: Timestamp;
   title: string;
   content: string;


### PR DESCRIPTION
## 変更概要
- 日記カードから共有中の日記を個別に停止できるようにする
- 共有停止後の再共有で新しいURLを発行し、従来形式の共有URLにも対応する
- 元日記の削除前に共有を停止し、公開コピーの残存を防ぐ
- お気に入り一覧の取得時に、参照先がないfavorite文書を所有者権限で自動削除する
- 関連するテストとFirestoreドキュメントを更新する

## 検証
- `pnpm test`（29ファイル、154件成功）
- 変更対象ファイルのESLint成功
- `pnpm build`成功
- Prettier check成功
- `git diff --check`成功

## 既存の問題
- `pnpm lint`全体実行はdevelopment既存の3件のエラーで失敗
  - `ProfileSettingsForm.tsx`の未使用import 2件
  - `useMonthSelector.ts`の既存Hookルール違反 1件
- buildには既存のchunk size警告あり

## 対象外
- 共有ページから過去に取得されたStorage画像の直接URL失効は対象外