### PR TITLE
日記作成の進行表示を改善

### DIFF
--- a/src/features/createDiary/components/DiaryCreationProgressDialog.test.tsx
+++ b/src/features/createDiary/components/DiaryCreationProgressDialog.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { DiaryCreationProgress } from "../types";
+import { DiaryCreationProgressDialog } from "./DiaryCreationProgressDialog";
+
+const standardProgress: DiaryCreationProgress = {
+  saveMode: "standard",
+  metadata: "active",
+  illustration: null,
+  persistence: "pending",
+};
+
+describe("DiaryCreationProgressDialog", () => {
+  it("通常保存ではタイトル・タグと保存の工程だけを表示する", () => {
+    render(<DiaryCreationProgressDialog progress={standardProgress} />);
+
+    expect(screen.getByRole("dialog", { name: "日記を作成中" })).toBeVisible();
+    expect(screen.getByText("タイトルとタグを生成中")).toBeVisible();
+    expect(screen.getByText("日記を保存予定")).toBeVisible();
+    expect(screen.queryByText(/水彩イラストを生成/)).not.toBeInTheDocument();
+  });
+
+  it("処理中だけprimary、完了・待機中はsecondary textで表示する", () => {
+    render(
+      <DiaryCreationProgressDialog
+        progress={{
+          saveMode: "illustrated",
+          metadata: "complete",
+          illustration: "active",
+          persistence: "pending",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("タイトルとタグを生成しました").closest("li"),
+    ).toHaveClass("text-muted-foreground");
+    expect(screen.getByText("水彩イラストを生成中").closest("li")).toHaveClass(
+      "text-primary",
+    );
+    expect(screen.getByText("水彩イラストを生成中")).toHaveClass(
+      "animate-loader-shimmer",
+      "font-normal",
+    );
+    expect(screen.getByText("日記を保存予定").closest("li")).toHaveClass(
+      "text-muted-foreground",
+    );
+    expect(document.querySelector(".lucide-tags")).toBeInTheDocument();
+    expect(document.querySelector(".lucide-image")).toBeInTheDocument();
+    expect(document.querySelector(".lucide-cloud-upload")).toBeInTheDocument();
+  });
+
+  it("表示用タイトル、説明、装飾アイコンを表示しない", () => {
+    render(<DiaryCreationProgressDialog progress={standardProgress} />);
+
+    expect(screen.getByText("日記を作成中")).toHaveClass("sr-only");
+    expect(
+      screen.queryByText("MemoirAIが日記を仕上げています"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/内容を読み取り、振り返りやすい日記/),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector(".lucide-sparkles")).not.toBeInTheDocument();
+  });
+
+  it("Escapeや外側操作では閉じない", async () => {
+    const user = userEvent.setup();
+    render(<DiaryCreationProgressDialog progress={standardProgress} />);
+
+    await user.keyboard("{Escape}");
+    fireEvent.pointerDown(document.body);
+
+    expect(screen.getByRole("dialog", { name: "日記を作成中" })).toBeVisible();
+  });
+
+  it("進行状態がなければ表示しない", () => {
+    render(<DiaryCreationProgressDialog progress={null} />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/createDiary/components/DiaryCreationProgressDialog.tsx
+++ b/src/features/createDiary/components/DiaryCreationProgressDialog.tsx
@@ -1,0 +1,95 @@
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { CloudUpload, Image, Tags, type LucideIcon } from "lucide-react";
+import type { DiaryCreationProgress, DiaryCreationStepStatus } from "../types";
+
+type DiaryCreationProgressDialogProps = {
+  progress: DiaryCreationProgress | null;
+};
+
+type ProgressStepProps = {
+  status: DiaryCreationStepStatus;
+  icon: LucideIcon;
+  labels: Record<DiaryCreationStepStatus, string>;
+};
+
+const ProgressStep = ({ status, icon: Icon, labels }: ProgressStepProps) => {
+  const isActive = status === "active";
+
+  return (
+    <li
+      data-status={status}
+      className={cn(
+        "flex items-center gap-2.5 py-2 text-sm transition-colors motion-reduce:transition-none",
+        isActive ? "text-primary" : "text-muted-foreground",
+      )}
+    >
+      <Icon className="size-4 shrink-0" aria-hidden="true" />
+      <span
+        className={cn(
+          "leading-6",
+          isActive &&
+            "animate-loader-shimmer bg-gradient-to-r from-primary via-primary/15 to-primary bg-[length:240%_100%] bg-clip-text font-normal text-transparent drop-shadow-[0_0_8px_color-mix(in_oklab,var(--color-primary)_30%,transparent)] motion-reduce:animate-none motion-reduce:bg-none motion-reduce:text-primary motion-reduce:drop-shadow-none",
+        )}
+      >
+        {labels[status]}
+      </span>
+    </li>
+  );
+};
+
+export const DiaryCreationProgressDialog = ({
+  progress,
+}: DiaryCreationProgressDialogProps) => {
+  const isOpen = progress !== null;
+
+  return (
+    <Dialog open={isOpen}>
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-w-sm p-5 [&>button]:hidden"
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
+        <DialogTitle className="sr-only">日記を作成中</DialogTitle>
+        <div role="status" aria-live="polite" aria-busy={isOpen}>
+          {progress && (
+            <ol className="space-y-1">
+              <ProgressStep
+                status={progress.metadata}
+                icon={Tags}
+                labels={{
+                  pending: "タイトルとタグを生成予定",
+                  active: "タイトルとタグを生成中",
+                  complete: "タイトルとタグを生成しました",
+                }}
+              />
+
+              {progress.illustration && (
+                <ProgressStep
+                  status={progress.illustration}
+                  icon={Image}
+                  labels={{
+                    pending: "水彩イラストを生成予定",
+                    active: "水彩イラストを生成中",
+                    complete: "水彩イラストを生成しました",
+                  }}
+                />
+              )}
+
+              <ProgressStep
+                status={progress.persistence}
+                icon={CloudUpload}
+                labels={{
+                  pending: "日記を保存予定",
+                  active: "日記を保存中",
+                  complete: "日記を保存しました",
+                }}
+              />
+            </ol>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/createDiary/components/DiarySaveButton.test.tsx
+++ b/src/features/createDiary/components/DiarySaveButton.test.tsx
@@ -70,6 +70,21 @@ describe("DiarySaveButton", () => {
     ).toBeDisabled();
   });
 
+  it("通常保存の生成中はタイトル生成を案内する", () => {
+    render(
+      <DiarySaveButton
+        saveMode="standard"
+        createPhase="generating"
+        onSaveModeChange={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "タイトルを生成中..." }),
+    ).toBeDisabled();
+  });
+
   it("再マウント時は通常保存へ戻る", async () => {
     const user = userEvent.setup();
     const { unmount } = render(<SaveButtonHarness />);

--- a/src/features/createDiary/components/DiarySaveButton.tsx
+++ b/src/features/createDiary/components/DiarySaveButton.tsx
@@ -25,7 +25,11 @@ const getSaveButtonLabel = (
   saveMode: DiarySaveMode,
   createPhase: CreatePhase,
 ) => {
-  if (createPhase === "generating") return "画像を生成中...";
+  if (createPhase === "generating") {
+    return saveMode === "illustrated"
+      ? "画像を生成中..."
+      : "タイトルを生成中...";
+  }
   if (createPhase === "saving") return "保存中...";
 
   return saveMode === "illustrated" ? "絵日記で保存" : "保存";

--- a/src/features/createDiary/components/NewDiaryView.tsx
+++ b/src/features/createDiary/components/NewDiaryView.tsx
@@ -33,6 +33,7 @@ import { useFetchDiary } from "../hooks/useFetchDiary";
 import { usePickMessages } from "../hooks/usePickMessages";
 import { useDiaryDetailStore } from "../provider/DiaryDetailProvider";
 import type { DiarySaveMode } from "../types";
+import { DiaryCreationProgressDialog } from "./DiaryCreationProgressDialog";
 import { DiaryImagePicker } from "./DiaryImagePicker";
 import { DiarySaveButton } from "./DiarySaveButton";
 
@@ -40,7 +41,8 @@ export const NewDiaryView = () => {
   const navigate = useNavigate();
   const { date, setDate } = useDiaryDetailStore();
   useFetchDiary();
-  const { createPhase, isCreating, onSave } = useCreateDiary();
+  const { createPhase, creationProgress, isCreating, onSave } =
+    useCreateDiary();
   const {
     cards,
     tagInputs,
@@ -109,7 +111,11 @@ export const NewDiaryView = () => {
       }
     }
 
-    await onSave(saveMode);
+    try {
+      await onSave(saveMode);
+    } catch {
+      return;
+    }
     await completeDraft();
     const dateString = format(date, "yyyy-MM-dd");
     navigate(`${PATHS.diaries.path}/${dateString}`);
@@ -434,6 +440,8 @@ export const NewDiaryView = () => {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <DiaryCreationProgressDialog progress={creationProgress} />
     </div>
   );
 };

--- a/src/features/createDiary/hooks/useCreateDiary.test.ts
+++ b/src/features/createDiary/hooks/useCreateDiary.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActiveUserMemoryContext } from "@/types/memory";
 import { useCreateDiary } from "./useCreateDiary";
@@ -25,7 +25,8 @@ const mocks = vi.hoisted(() => ({
   invalidateSearch: vi.fn(),
   requestRefresh: vi.fn(),
   generateId: vi.fn(),
-  toastPromise: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock("@/contexts/LocalUserContext", () => ({
@@ -80,7 +81,10 @@ vi.mock("@/stores/diaryRefreshStore", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { promise: mocks.toastPromise },
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError,
+  },
 }));
 
 const createCard = (body: string, files: File[] = []) => ({
@@ -97,6 +101,17 @@ const createCard = (body: string, files: File[] = []) => ({
   isCollapsed: false,
   isRemoving: false,
 });
+
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+};
 
 const memoryContext: ActiveUserMemoryContext = {
   profileFacts: [
@@ -149,6 +164,96 @@ beforeEach(() => {
 });
 
 describe("useCreateDiary", () => {
+  it("通常保存の生成と保存の進行状態を公開する", async () => {
+    mocks.cards = [createCard("桜を見ました")];
+    const title = createDeferred<{
+      response: { text: () => string };
+    }>();
+    const add = createDeferred<void>();
+    mocks.generateTitle.mockReturnValue(title.promise);
+    mocks.add.mockReturnValue(add.promise);
+    const { result } = renderHook(() => useCreateDiary());
+    let savePromise!: Promise<void>;
+
+    await act(async () => {
+      savePromise = result.current.onSave("standard");
+      await Promise.resolve();
+    });
+
+    expect(result.current.creationProgress).toEqual({
+      saveMode: "standard",
+      metadata: "active",
+      illustration: null,
+      persistence: "pending",
+    });
+
+    title.resolve({
+      response: { text: () => JSON.stringify({ title: "🌸 春の散歩" }) },
+    });
+
+    await waitFor(() => {
+      expect(result.current.creationProgress).toEqual({
+        saveMode: "standard",
+        metadata: "complete",
+        illustration: null,
+        persistence: "active",
+      });
+    });
+
+    add.resolve();
+    await act(async () => savePromise);
+
+    expect(result.current.creationProgress).toBeNull();
+  });
+
+  it("絵日記の画像が先に完成した場合も工程ごとに完了を反映する", async () => {
+    mocks.cards = [createCard("桜を見ました")];
+    const title = createDeferred<{
+      response: { text: () => string };
+    }>();
+    const illustration = createDeferred<File>();
+    const add = createDeferred<void>();
+    mocks.generateTitle.mockReturnValue(title.promise);
+    mocks.generateIllustration.mockReturnValue(illustration.promise);
+    mocks.add.mockReturnValue(add.promise);
+    const { result } = renderHook(() => useCreateDiary());
+    let savePromise!: Promise<void>;
+
+    await act(async () => {
+      savePromise = result.current.onSave("illustrated");
+      await Promise.resolve();
+    });
+
+    illustration.resolve(
+      new File(["generated"], "generated.png", { type: "image/png" }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.creationProgress).toMatchObject({
+        metadata: "active",
+        illustration: "complete",
+        persistence: "pending",
+      });
+    });
+
+    title.resolve({
+      response: { text: () => JSON.stringify({ title: "🌸 春の散歩" }) },
+    });
+
+    await waitFor(() => {
+      expect(result.current.creationProgress).toMatchObject({
+        metadata: "complete",
+        illustration: "complete",
+        persistence: "active",
+      });
+    });
+
+    add.resolve();
+    await act(async () => savePromise);
+
+    expect(result.current.creationProgress).toBeNull();
+  });
+
   it("通常保存では画像生成を呼ばない", async () => {
     mocks.cards = [createCard("桜を見ました"), createCard("本を読みました")];
     const { result } = renderHook(() => useCreateDiary());
@@ -159,6 +264,7 @@ describe("useCreateDiary", () => {
 
     expect(mocks.generateIllustration).not.toHaveBeenCalled();
     expect(mocks.add).toHaveBeenCalledTimes(2);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("日記を作成しました🎊");
   });
 
   it("本文のある各セクションに1枚生成する", async () => {
@@ -284,6 +390,8 @@ describe("useCreateDiary", () => {
     expect(mocks.add).not.toHaveBeenCalled();
     expect(mocks.invalidateSearch).not.toHaveBeenCalled();
     expect(mocks.requestRefresh).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith("日記の作成に失敗しました");
+    expect(result.current.creationProgress).toBeNull();
   });
 
   it("タイトル生成失敗時もStorage・Firestoreを実行しない", async () => {
@@ -302,6 +410,23 @@ describe("useCreateDiary", () => {
 
     expect(mocks.upload).not.toHaveBeenCalled();
     expect(mocks.add).not.toHaveBeenCalled();
+    expect(result.current.creationProgress).toBeNull();
+  });
+
+  it("画像アップロード失敗時は保存工程を閉じてFirestoreを実行しない", async () => {
+    const manual = new File(["manual"], "manual.jpg", { type: "image/jpeg" });
+    mocks.cards = [createCard("桜を見ました", [manual])];
+    mocks.upload.mockRejectedValue(new Error("upload failed"));
+    const { result } = renderHook(() => useCreateDiary());
+
+    await expect(
+      act(async () => {
+        await result.current.onSave("standard");
+      }),
+    ).rejects.toThrow("upload failed");
+
+    expect(mocks.add).not.toHaveBeenCalled();
+    expect(result.current.creationProgress).toBeNull();
   });
 
   it("Firestore保存失敗時は生成画像を含むアップロード済み画像を削除する", async () => {
@@ -323,5 +448,6 @@ describe("useCreateDiary", () => {
       expect.objectContaining({ id: "generated.png" }),
       expect.objectContaining({ id: "manual.jpg" }),
     ]);
+    expect(result.current.creationProgress).toBeNull();
   });
 });

--- a/src/features/createDiary/hooks/useCreateDiary.ts
+++ b/src/features/createDiary/hooks/useCreateDiary.ts
@@ -21,7 +21,11 @@ import type {
 import { useCallback, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { type DiaryCardImage, useDiaryCard } from "./useDiaryCard";
-import type { DiarySaveMode } from "../types";
+import type {
+  DiaryCreationProgress,
+  DiaryCreationStepStatus,
+  DiarySaveMode,
+} from "../types";
 
 interface Tag {
   color: TagColor;
@@ -218,9 +222,8 @@ const uploadDiaryImages = async (
 };
 
 export const useCreateDiary = () => {
-  const [createPhase, setCreatePhase] = useState<
-    "idle" | "generating" | "saving"
-  >("idle");
+  const [creationProgress, setCreationProgress] =
+    useState<DiaryCreationProgress | null>(null);
   const { localUser } = useLocalUser();
   const { cards } = useDiaryCard();
 
@@ -234,17 +237,52 @@ export const useCreateDiary = () => {
         throw new Error("生成画像を追加するには画像を1枚削除してください");
       }
 
-      setCreatePhase(saveMode === "illustrated" ? "generating" : "saving");
+      setCreationProgress({
+        saveMode,
+        metadata: "active",
+        illustration: saveMode === "illustrated" ? "active" : null,
+        persistence: "pending",
+      });
+
+      const completeStep = (
+        step: "metadata" | "illustration",
+        status: DiaryCreationStepStatus = "complete",
+      ) => {
+        setCreationProgress((progress) =>
+          progress ? { ...progress, [step]: status } : progress,
+        );
+      };
+
       try {
         const memoryContextPromise = getActiveMemoryContext(localUser.uid);
         const diaryPreparations = diaries.map((diary) =>
           prepareDiary(diary, memoryContextPromise, saveMode),
         );
-        const preparedDiaries = await Promise.all(
-          diaryPreparations.map(completeDiaryPreparation),
-        );
+        const metadataProgressPromise = Promise.all(
+          diaryPreparations.map((preparation) => preparation.metaPromise),
+        ).then(() => completeStep("metadata"));
+        const illustrationProgressPromise =
+          saveMode === "illustrated"
+            ? Promise.all(
+                diaryPreparations.map(
+                  (preparation) => preparation.illustrationPromise,
+                ),
+              ).then(() => completeStep("illustration"))
+            : Promise.resolve();
+        const [preparedDiaries] = await Promise.all([
+          Promise.all(diaryPreparations.map(completeDiaryPreparation)),
+          metadataProgressPromise,
+          illustrationProgressPromise,
+        ]);
 
-        setCreatePhase("saving");
+        setCreationProgress((progress) =>
+          progress
+            ? {
+                ...progress,
+                persistence: "active",
+              }
+            : progress,
+        );
 
         // 並列でカードの追加処理を実行
         const addPromises = preparedDiaries.map(async (preparation) => {
@@ -304,7 +342,7 @@ export const useCreateDiary = () => {
         invalidateDiarySearchCache();
         requestDiaryRefresh();
       } finally {
-        setCreatePhase("idle");
+        setCreationProgress(null);
       }
     },
     [localUser?.uid],
@@ -325,24 +363,30 @@ export const useCreateDiary = () => {
 
   const onSave = useCallback(
     async (saveMode: DiarySaveMode) => {
-      const promise = createDiaries(diariesToCreate, saveMode);
-      toast.promise(promise, {
-        loading:
-          saveMode === "illustrated" ? "絵日記を作成中..." : "日記を作成中...",
-        success: () => "日記を作成しました🎊",
-        error: (error) =>
+      try {
+        await createDiaries(diariesToCreate, saveMode);
+        toast.success("日記を作成しました🎊");
+      } catch (error) {
+        toast.error(
           error instanceof DiaryIllustrationError
             ? "画像を生成できませんでした。再試行するか、通常保存に切り替えてください"
             : "日記の作成に失敗しました",
-      });
-      await promise;
+        );
+        throw error;
+      }
     },
     [createDiaries, diariesToCreate],
   );
 
   return {
-    createPhase,
-    isCreating: createPhase !== "idle",
+    createPhase:
+      creationProgress === null
+        ? ("idle" as const)
+        : creationProgress.persistence === "active"
+          ? ("saving" as const)
+          : ("generating" as const),
+    creationProgress,
+    isCreating: creationProgress !== null,
     onSave,
   };
 };

--- a/src/features/createDiary/types.ts
+++ b/src/features/createDiary/types.ts
@@ -1,1 +1,10 @@
 export type DiarySaveMode = "standard" | "illustrated";
+
+export type DiaryCreationStepStatus = "pending" | "active" | "complete";
+
+export type DiaryCreationProgress = {
+  saveMode: DiarySaveMode;
+  metadata: DiaryCreationStepStatus;
+  illustration: DiaryCreationStepStatus | null;
+  persistence: DiaryCreationStepStatus;
+};


### PR DESCRIPTION
## 変更概要
- 日記保存中のタイトル・タグ生成、イラスト生成、保存処理を工程別に表示
- Codex風のシンプルな進行モーダルと状態別の文言・色・シマーを追加
- 右下の進行toastを廃止し、成功・失敗通知だけを維持
- 生成・upload・Firestore失敗時の進行状態解除をテスト

## 検証結果
- `pnpm exec prettier --check`（対象8ファイル）
- `pnpm exec eslint`（対象8ファイル）
- `pnpm exec vitest run`（対象3ファイル、23 tests passed）
- `pnpm exec tsc -b`
- `pnpm exec vite build`
- `git diff --check`

## 補足
- 保存中のブラウザバック、再読み込み、タブ終了を安全にするバックグラウンド処理は対象外です。