### PR TITLE
improve: 初期読み込み表示を統一

### DIFF
--- a/src/layout/AppShellLayout.test.tsx
+++ b/src/layout/AppShellLayout.test.tsx
@@ -97,7 +97,7 @@ describe("AppShellLayout", () => {
     expect(screen.getByTestId("outlet-user")).toHaveTextContent("user-1");
   });
 
-  it("認証済みでも同意確認中はOutletを描画しない", () => {
+  it("認証済みでも同意確認中は共通のloadingだけを表示する", () => {
     useAuthCheckMock.mockReturnValue({
       loading: false,
       user: { uid: "user-1" } as User,
@@ -109,7 +109,7 @@ describe("AppShellLayout", () => {
 
     renderShell();
 
-    expect(screen.getByText("同意状況を確認中...")).toBeInTheDocument();
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
     expect(screen.queryByTestId("outlet-user")).not.toBeInTheDocument();
   });
 
@@ -134,7 +134,7 @@ describe("AppShellLayout", () => {
     expect(screen.queryByTestId("outlet-user")).not.toBeInTheDocument();
   });
 
-  it("同意済みでも利用準備中はapp contentを描画しない", () => {
+  it("同意済みでも利用準備中は共通のloadingだけを表示する", () => {
     useAuthCheckMock.mockReturnValue({
       loading: false,
       user: { uid: "user-1" } as User,
@@ -146,7 +146,7 @@ describe("AppShellLayout", () => {
 
     renderShell();
 
-    expect(screen.getByText("利用準備中...")).toBeInTheDocument();
+    expect(screen.getByText("読み込み中...")).toBeInTheDocument();
     expect(screen.queryByTestId("outlet-user")).not.toBeInTheDocument();
   });
 

--- a/src/layout/AppShellLayout.tsx
+++ b/src/layout/AppShellLayout.tsx
@@ -44,18 +44,7 @@ export const AppShellLayout = () => {
           (userInitialization.status === "idle" ||
             userInitialization.status === "loading"))))
   ) {
-    return (
-      <LoadingScreen
-        variant="page"
-        title={
-          loading
-            ? undefined
-            : legalAcceptance.status === "accepted"
-              ? "利用準備中..."
-              : "同意状況を確認中..."
-        }
-      />
-    );
+    return <LoadingScreen variant="page" />;
   }
 
   if (user && legalAcceptance.status === "error") {


### PR DESCRIPTION
## 変更概要

- 認証確認・同意確認・ユーザー初期化の待機表示を「読み込み中...」へ統一
- 初期化処理の順序と既存のエラー表示は維持
- 同意確認中・利用準備中の回帰テストを更新

## 検証結果

- ✅ `pnpm exec vitest run src/layout/AppShellLayout.test.tsx`（7件成功）
- ✅ 変更ファイルのESLint・Prettier
- ✅ `pnpm build`
- ✅ `git diff --check`
- ⚠️ `pnpm lint` は今回の変更と無関係な既存エラー3件で失敗
- ⚠️ 全体テストは今回の変更と無関係な既存テスト2件（DiaryUnshareDialog、LegalPage）で失敗
