### PR TITLE
feat: 日記本文をMarkdownに対応

### DIFF
--- a/docs/project/frontend/ui.md
+++ b/docs/project/frontend/ui.md
@@ -5,7 +5,7 @@
 ## Theme and layout
 
 - 通常色は`bg-background`、`text-foreground`、`text-muted-foreground`、`border-border`、`bg-primary`、`text-destructive`などを使います。お気に入りのactive iconは`text-favorite` / `fill-favorite`を使います。
-- 日記本文は`whitespace-pre-wrap text-foreground/80`をpreviewと共有表示で使います。
+- 日記本文は`react-markdown`と`remark-gfm`で安全に描画します。詳細・共有では見出し、強調、list、引用、code、tableなどを組版し、月一覧・検索結果ではMarkdown記法を除いたplain text相当の抜粋を表示します。HTMLとMarkdown画像は描画せず、通常textの単一改行は維持します。
 - route contentの外枠は`MainLayout`の中央寄せ・最大幅・横paddingです。
 - responsiveは既存の`sm` / `md` breakpointと`useIsMobile`を参照します。
 - 認証済み画面は`md`未満で48px高のモバイルヘッダーを表示し、`md`以上はサイドバーへ操作を集約する。サイドバー閉鎖時は左上の小型操作群とコンテンツ用の左余白を表示する。
@@ -20,6 +20,7 @@
 - Dialogは`DialogContent`、`DialogHeader`、`DialogTitle`、必要に応じて`DialogDescription` / `DialogFooter`を組み合わせます。
 - cancelは`outline`、削除・破棄は`destructive`です。
 - 日付選択は`DiaryEditDialog`の`Popover modal`構成です。
+- 日記の作成・編集はshadcn / Radix `Tabs`で本文の入力とMarkdownプレビューを切り替えます。
 - DropdownからDialogを開く既存例は、menuを閉じて次frameでDialogを開きます。
 - page / section loadingは`LoadingScreen`、一覧・設定はSkeleton、compact操作はSpinnerまたは処理中labelです。
 - Settings Dialogはプロフィール、一般、メモリ、アカウントの4 tabです。アカウント削除はnested Dialogで説明・Google再認証を行い、処理中は外側を含めてcloseを抑止します。

--- a/scripts/seedData.json
+++ b/scripts/seedData.json
@@ -242,6 +242,28 @@
           ]
         },
         {
+          "id": "seed-diary-current-markdown",
+          "monthOffset": 0,
+          "day": 16,
+          "hour": 20,
+          "title": "📝 Markdownで残す一日",
+          "content": "## 今日のハイライト\n\n**Markdownで振り返りを書けるようになった。** 入力した内容を `プレビュー` で確かめながら、出来事を整理できた。\n\n### 今日できたこと\n\n- [x] 朝の散歩をする\n- [x] 読みかけの本を20ページ読む\n- [ ] 週末の写真を整理する\n\n> 書き方が少し変わるだけで、いつもの一日も見返しやすくなる。\n\n詳しい記法は[Markdown Guide](https://www.markdownguide.org/basic-syntax/)も参考になった。\n\n---\n\n| 時間 | 出来事 | 気分 |\n| --- | --- | --- |\n| 朝 | 公園を散歩 | すっきり |\n| 昼 | 新しい表示を確認 | 集中 |\n| 夜 | 一日を振り返る | 穏やか |",
+          "tags": [
+            {
+              "name": "Markdown",
+              "color": "indigo"
+            },
+            {
+              "name": "振り返り",
+              "color": "violet"
+            },
+            {
+              "name": "UI確認",
+              "color": "sky"
+            }
+          ]
+        },
+        {
           "id": "seed-diary-current-07",
           "monthOffset": 0,
           "day": 20,

--- a/src/components/shared/diary/DiaryMarkdown.test.tsx
+++ b/src/components/shared/diary/DiaryMarkdown.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DiaryMarkdown } from "./DiaryMarkdown";
+
+const markdown = `# 今日の記録
+
+一行目
+二行目
+
+**大切なこと**と~~取り消したこと~~
+
+- [x] 完了したこと
+- [ ] これからすること
+
+> 覚えておきたい言葉
+
+| 時間 | 出来事 |
+| --- | --- |
+| 朝 | 散歩 |
+
+\`プレビュー\`で確認する。
+
+[Markdown Guide](https://www.markdownguide.org/)
+
+![外部画像](https://example.com/tracking.png)
+
+<span data-danger="true">HTMLの内容</span>`;
+
+describe("DiaryMarkdown", () => {
+  it("GFMを日記本文向けの要素として描画する", () => {
+    render(<DiaryMarkdown>{markdown}</DiaryMarkdown>);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "今日の記録" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("大切なこと").tagName).toBe("STRONG");
+    expect(screen.getByText("取り消したこと").tagName).toBe("DEL");
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+    expect(screen.getAllByRole("checkbox")[0]).toBeChecked();
+    expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("プレビュー").tagName).toBe("CODE");
+  });
+
+  it("通常テキストの単一改行を維持する", () => {
+    render(<DiaryMarkdown>{markdown}</DiaryMarkdown>);
+
+    const paragraph = screen.getByText((_, element) =>
+      Boolean(element?.textContent === "一行目\n二行目"),
+    );
+    expect(paragraph).toHaveClass("whitespace-pre-wrap");
+  });
+
+  it("外部リンクを安全に開き、HTMLとMarkdown画像を描画しない", () => {
+    const { container } = render(<DiaryMarkdown>{markdown}</DiaryMarkdown>);
+
+    expect(
+      screen.getByRole("link", { name: "Markdown Guide" }),
+    ).toHaveAttribute("target", "_blank");
+    expect(
+      screen.getByRole("link", { name: "Markdown Guide" }),
+    ).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(container.querySelector("[data-danger]")).not.toBeInTheDocument();
+    expect(screen.getByText("HTMLの内容")).toBeInTheDocument();
+  });
+
+  it("抜粋ではMarkdown要素とリンク先を除いて本文だけを表示する", () => {
+    const { container } = render(
+      <DiaryMarkdown variant="excerpt">{markdown}</DiaryMarkdown>,
+    );
+
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(container).toHaveTextContent("今日の記録");
+    expect(container).toHaveTextContent("Markdown Guide");
+    expect(container.textContent).not.toContain("https://");
+  });
+});

--- a/src/components/shared/diary/DiaryMarkdown.tsx
+++ b/src/components/shared/diary/DiaryMarkdown.tsx
@@ -1,0 +1,211 @@
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+type DiaryMarkdownProps = {
+  children: string;
+  className?: string;
+  variant?: "detail" | "excerpt";
+};
+
+const detailComponents: Components = {
+  h1: ({ children }) => (
+    <h1 className="mt-7 text-2xl font-bold tracking-tight text-foreground first:mt-0">
+      {children}
+    </h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className="mt-7 text-xl font-semibold tracking-tight text-foreground first:mt-0">
+      {children}
+    </h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className="mt-6 text-lg font-semibold tracking-tight text-foreground first:mt-0">
+      {children}
+    </h3>
+  ),
+  h4: ({ children }) => (
+    <h4 className="mt-5 text-base font-semibold text-foreground first:mt-0">
+      {children}
+    </h4>
+  ),
+  h5: ({ children }) => (
+    <h5 className="mt-5 text-sm font-semibold text-foreground first:mt-0">
+      {children}
+    </h5>
+  ),
+  h6: ({ children }) => (
+    <h6 className="mt-5 text-sm font-medium text-muted-foreground first:mt-0">
+      {children}
+    </h6>
+  ),
+  p: ({ children }) => (
+    <p className="mt-3 leading-7 whitespace-pre-wrap first:mt-0">{children}</p>
+  ),
+  ul: ({ children, className }) => (
+    <ul
+      className={cn(
+        "mt-3 list-disc space-y-1.5 pl-6 leading-7 first:mt-0",
+        className?.includes("contains-task-list") && "list-none pl-0",
+      )}
+    >
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className="mt-3 list-decimal space-y-1.5 pl-6 leading-7 first:mt-0">
+      {children}
+    </ol>
+  ),
+  li: ({ children, className }) => (
+    <li
+      className={cn(
+        "pl-1 marker:text-muted-foreground",
+        className?.includes("task-list-item") && "list-none pl-0",
+      )}
+    >
+      {children}
+    </li>
+  ),
+  input: ({ type, checked, disabled }) =>
+    type === "checkbox" ? (
+      <input
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        readOnly
+        className="mr-2 size-4 translate-y-0.5 accent-primary"
+      />
+    ) : null,
+  blockquote: ({ children }) => (
+    <blockquote className="mt-4 border-l-2 border-primary/50 pl-4 text-muted-foreground italic first:mt-0">
+      {children}
+    </blockquote>
+  ),
+  a: ({ children, href }) => {
+    const isExternal =
+      href?.startsWith("http://") || href?.startsWith("https://");
+
+    return (
+      <a
+        href={href}
+        target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
+        className="rounded-sm font-medium text-primary underline decoration-primary/40 underline-offset-4 transition-colors hover:decoration-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+      >
+        {children}
+      </a>
+    );
+  },
+  strong: ({ children }) => (
+    <strong className="font-semibold text-foreground">{children}</strong>
+  ),
+  del: ({ children }) => (
+    <del className="text-muted-foreground decoration-muted-foreground/70">
+      {children}
+    </del>
+  ),
+  hr: () => <hr className="my-6 border-border" />,
+  code: ({ children }) => (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.875em] text-foreground">
+      {children}
+    </code>
+  ),
+  pre: ({ children }) => (
+    <pre className="mt-4 overflow-x-auto rounded-md border bg-muted/60 p-4 text-sm leading-6 first:mt-0 [&>code]:bg-transparent [&>code]:p-0">
+      {children}
+    </pre>
+  ),
+  table: ({ children }) => (
+    <div className="mt-4 overflow-x-auto rounded-md border first:mt-0">
+      <table className="w-full min-w-max border-collapse text-left text-sm [&_tbody_tr:last-child_td]:border-b-0">
+        {children}
+      </table>
+    </div>
+  ),
+  th: ({ children }) => (
+    <th className="border-b bg-muted/60 px-3 py-2 font-semibold text-foreground">
+      {children}
+    </th>
+  ),
+  td: ({ children }) => (
+    <td className="border-b px-3 py-2 align-top">{children}</td>
+  ),
+  img: () => null,
+};
+
+const ExcerptBlock = ({ children }: { children?: ReactNode }) => (
+  <span>{children} </span>
+);
+
+const ExcerptInline = ({ children }: { children?: ReactNode }) => (
+  <span>{children}</span>
+);
+
+const excerptComponents: Components = {
+  h1: ExcerptBlock,
+  h2: ExcerptBlock,
+  h3: ExcerptBlock,
+  h4: ExcerptBlock,
+  h5: ExcerptBlock,
+  h6: ExcerptBlock,
+  p: ExcerptBlock,
+  ul: ExcerptInline,
+  ol: ExcerptInline,
+  li: ExcerptBlock,
+  blockquote: ExcerptBlock,
+  pre: ExcerptBlock,
+  code: ExcerptInline,
+  table: ExcerptInline,
+  thead: ExcerptInline,
+  tbody: ExcerptInline,
+  tr: ExcerptInline,
+  th: ExcerptBlock,
+  td: ExcerptBlock,
+  a: ExcerptInline,
+  strong: ExcerptInline,
+  em: ExcerptInline,
+  del: ExcerptInline,
+  br: () => <span> </span>,
+  hr: () => <span> </span>,
+  input: () => null,
+  img: () => null,
+};
+
+export const DiaryMarkdown = ({
+  children,
+  className,
+  variant = "detail",
+}: DiaryMarkdownProps) => {
+  if (variant === "excerpt") {
+    return (
+      <span className={className}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={excerptComponents}
+          skipHtml
+        >
+          {children}
+        </ReactMarkdown>
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "max-w-[70ch] text-foreground/80 [&_blockquote>p]:mt-0 [&_li>p]:mt-0",
+        className,
+      )}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={detailComponents}
+        skipHtml
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};

--- a/src/components/shared/diary/DiaryMarkdownEditor.test.tsx
+++ b/src/components/shared/diary/DiaryMarkdownEditor.test.tsx
@@ -1,0 +1,100 @@
+import { Textarea } from "@/components/ui/textarea";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { DiaryMarkdownEditor } from "./DiaryMarkdownEditor";
+
+const EditorHarness = () => {
+  const [content, setContent] = useState("# 最初の見出し");
+
+  return (
+    <DiaryMarkdownEditor content={content} resetKey="diary-1">
+      <Textarea
+        aria-label="日記本文"
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+      />
+    </DiaryMarkdownEditor>
+  );
+};
+
+describe("DiaryMarkdownEditor", () => {
+  it("入力値を保持したままMarkdownプレビューへ切り替える", async () => {
+    const user = userEvent.setup();
+    render(<EditorHarness />);
+
+    const textarea = screen.getByRole("textbox", { name: "日記本文" });
+    await user.clear(textarea);
+    await user.type(textarea, "## 更新した見出し");
+    await user.click(screen.getByRole("tab", { name: "プレビュー" }));
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "更新した見出し" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "入力" }));
+    expect(screen.getByRole("textbox", { name: "日記本文" })).toHaveValue(
+      "## 更新した見出し",
+    );
+  });
+
+  it("空の本文ではプレビュー用の案内を表示する", async () => {
+    const user = userEvent.setup();
+    render(
+      <DiaryMarkdownEditor content="  " resetKey="empty-diary">
+        <Textarea aria-label="日記本文" value="  " readOnly />
+      </DiaryMarkdownEditor>,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "プレビュー" }));
+
+    expect(
+      screen.getByText("プレビューする本文がありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("矢印キーで入力とプレビューを切り替えられる", async () => {
+    const user = userEvent.setup();
+    render(<EditorHarness />);
+
+    const writeTab = screen.getByRole("tab", { name: "入力" });
+    writeTab.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "プレビュー" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(
+      screen.getByRole("heading", { level: 1, name: "最初の見出し" }),
+    ).toBeInTheDocument();
+  });
+
+  it("対象日記が変わると入力タブへ戻る", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <DiaryMarkdownEditor content="# 本文" resetKey="diary-1">
+        <Textarea aria-label="日記本文" value="# 本文" readOnly />
+      </DiaryMarkdownEditor>,
+    );
+    await user.click(screen.getByRole("tab", { name: "プレビュー" }));
+    expect(screen.getByRole("tab", { name: "プレビュー" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    rerender(
+      <DiaryMarkdownEditor content="# 本文" resetKey="diary-2">
+        <Textarea aria-label="日記本文" value="# 本文" readOnly />
+      </DiaryMarkdownEditor>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "入力" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  });
+});

--- a/src/components/shared/diary/DiaryMarkdownEditor.tsx
+++ b/src/components/shared/diary/DiaryMarkdownEditor.tsx
@@ -1,0 +1,71 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { Eye, PencilLine } from "lucide-react";
+import { useEffect, useState, type ReactNode } from "react";
+import { DiaryMarkdown } from "./DiaryMarkdown";
+
+type DiaryMarkdownEditorProps = {
+  children: ReactNode;
+  content: string;
+  className?: string;
+  disabled?: boolean;
+  previewClassName?: string;
+  resetKey: string;
+};
+
+type EditorMode = "write" | "preview";
+
+export const DiaryMarkdownEditor = ({
+  children,
+  content,
+  className,
+  disabled = false,
+  previewClassName,
+  resetKey,
+}: DiaryMarkdownEditorProps) => {
+  const [mode, setMode] = useState<EditorMode>("write");
+
+  useEffect(() => {
+    setMode("write");
+  }, [resetKey]);
+
+  return (
+    <Tabs
+      value={mode}
+      onValueChange={(value) => setMode(value as EditorMode)}
+      className={className}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <TabsList aria-label="本文の表示モード" className="h-8">
+          <TabsTrigger value="write" disabled={disabled} className="text-xs">
+            <PencilLine aria-hidden="true" />
+            入力
+          </TabsTrigger>
+          <TabsTrigger value="preview" disabled={disabled} className="text-xs">
+            <Eye aria-hidden="true" />
+            プレビュー
+          </TabsTrigger>
+        </TabsList>
+      </div>
+      <TabsContent value="write" className="mt-0">
+        {children}
+      </TabsContent>
+      <TabsContent value="preview" className="mt-0">
+        <div
+          className={cn(
+            "min-h-48 overflow-auto rounded-md border bg-background px-3 py-2",
+            previewClassName,
+          )}
+        >
+          {content.trim() ? (
+            <DiaryMarkdown>{content}</DiaryMarkdown>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              プレビューする本文がありません
+            </p>
+          )}
+        </div>
+      </TabsContent>
+    </Tabs>
+  );
+};

--- a/src/features/createDiary/components/NewDiaryView.tsx
+++ b/src/features/createDiary/components/NewDiaryView.tsx
@@ -1,4 +1,5 @@
 import { useRotatingText } from "@/components/shared/common/useRotatingText";
+import { DiaryMarkdownEditor } from "@/components/shared/diary/DiaryMarkdownEditor";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -265,13 +266,21 @@ export const NewDiaryView = () => {
               </CardHeader>
 
               <CardContent>
-                <Textarea
-                  id={`diary-body-${card.id}`}
-                  placeholder={placeholderText}
-                  value={card.body}
-                  onChange={(e) => updateCardBody(card.id, e.target.value)}
-                  className="max-h-[500px] min-h-[300px] resize-none overflow-y-auto border-none leading-relaxed shadow placeholder:text-muted-foreground/30 focus-visible:ring-0"
-                />
+                <DiaryMarkdownEditor
+                  content={card.body}
+                  disabled={isCreating}
+                  resetKey={`${format(date, "yyyy-MM-dd")}:${card.id}`}
+                  previewClassName="max-h-[500px] min-h-[300px] border-none shadow"
+                >
+                  <Textarea
+                    id={`diary-body-${card.id}`}
+                    placeholder={placeholderText}
+                    value={card.body}
+                    disabled={isCreating}
+                    onChange={(e) => updateCardBody(card.id, e.target.value)}
+                    className="max-h-[500px] min-h-[300px] resize-none overflow-y-auto border-none leading-relaxed shadow placeholder:text-muted-foreground/30 focus-visible:ring-0"
+                  />
+                </DiaryMarkdownEditor>
 
                 <div className="h-px w-full bg-gradient-to-r from-transparent via-border to-transparent opacity-50" />
 

--- a/src/features/createDiary/hooks/useCreateDiary.test.ts
+++ b/src/features/createDiary/hooks/useCreateDiary.test.ts
@@ -286,6 +286,20 @@ describe("useCreateDiary", () => {
     expect(mocks.add).toHaveBeenCalledTimes(2);
   });
 
+  it("Markdown本文を変更せずに保存する", async () => {
+    const markdown = "## 今日の記録\n\n**大切な出来事**を書いた。";
+    mocks.cards = [createCard(markdown)];
+    const { result } = renderHook(() => useCreateDiary());
+
+    await act(async () => {
+      await result.current.onSave("standard");
+    });
+
+    expect(mocks.add).toHaveBeenCalledWith(
+      expect.objectContaining({ content: markdown }),
+    );
+  });
+
   it("保存済みメモリを1回取得して各セクションの画像生成へ渡す", async () => {
     mocks.cards = [createCard("桜を見ました"), createCard("本を読みました")];
     mocks.getMemory.mockResolvedValue(memoryContext);

--- a/src/features/diaries/components/DiaryEditDialog.test.tsx
+++ b/src/features/diaries/components/DiaryEditDialog.test.tsx
@@ -1,0 +1,51 @@
+import type { Diary } from "@/types/diary/diary";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Timestamp } from "firebase/firestore";
+import { describe, expect, it, vi } from "vitest";
+import { DiaryEditDialog } from "./DiaryEditDialog";
+
+const diary: Diary = {
+  id: "diary-1",
+  uid: "user-1",
+  date: Timestamp.fromDate(new Date(2026, 7, 20)),
+  title: "夏の記録",
+  content: "もとの本文",
+  tags: [],
+  createdAt: Timestamp.fromDate(new Date(2026, 7, 20)),
+};
+
+describe("DiaryEditDialog Markdown", () => {
+  it("プレビューしたMarkdown本文を変更せずに送信する", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    render(
+      <DiaryEditDialog
+        diary={diary}
+        isOpen
+        isSubmitting={false}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox", { name: "本文" });
+    const markdown = "## 更新した記録\n\n**大切な出来事**を書いた。";
+    await user.clear(textarea);
+    await user.type(textarea, markdown);
+    await user.click(screen.getByRole("tab", { name: "プレビュー" }));
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "更新した記録" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "入力" }));
+    await user.click(screen.getByRole("button", { name: "保存する" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ content: markdown }),
+      );
+    });
+  });
+});

--- a/src/features/diaries/components/DiaryEditDialog.tsx
+++ b/src/features/diaries/components/DiaryEditDialog.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { DiaryMarkdownEditor } from "@/components/shared/diary/DiaryMarkdownEditor";
 import { Calendar } from "@/components/ui/calendar";
 import {
   Dialog,
@@ -229,14 +230,20 @@ export const DiaryEditDialog = ({
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>本文</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        {...field}
-                        disabled={isSubmitting}
-                        className="min-h-48 resize-y"
-                        placeholder="本文を入力"
-                      />
-                    </FormControl>
+                    <DiaryMarkdownEditor
+                      content={field.value}
+                      disabled={isSubmitting}
+                      resetKey={`${diary.id}:${String(isOpen)}`}
+                    >
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          disabled={isSubmitting}
+                          className="min-h-48 resize-y"
+                          placeholder="本文を入力"
+                        />
+                      </FormControl>
+                    </DiaryMarkdownEditor>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/features/diaries/components/DiaryPreviewCard.tsx
+++ b/src/features/diaries/components/DiaryPreviewCard.tsx
@@ -1,5 +1,6 @@
 import LineIcon from "@/components/shared/Icons/LineIcon";
 import XIcon from "@/components/shared/Icons/XIcon";
+import { DiaryMarkdown } from "@/components/shared/diary/DiaryMarkdown";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -286,9 +287,7 @@ export const DiaryPreviewCard = ({
             </DropdownMenu>
           </CardHeader>
           <CardContent className="px-2">
-            <p className="max-w-[70ch] whitespace-pre-wrap text-foreground/80">
-              {diary.content}
-            </p>
+            <DiaryMarkdown>{diary.content}</DiaryMarkdown>
           </CardContent>
           <CardFooter className="flex items-end gap-3 p-0">
             {diary.tags.length >= 1 && (

--- a/src/features/home/diaryList/components/DiaryItem.tsx
+++ b/src/features/home/diaryList/components/DiaryItem.tsx
@@ -1,4 +1,5 @@
 import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { DiaryMarkdown } from "@/components/shared/diary/DiaryMarkdown";
 import {
   CardContent,
   CardFooter,
@@ -47,8 +48,8 @@ export const DiaryItem = (props: DiaryItemProps) => {
             <CardTitle className="text-lg">{diary.title}</CardTitle>
           </CardHeader>
           <CardContent className="mb-4 p-0">
-            <p className="line-clamp-4 text-sm leading-relaxed whitespace-pre-wrap text-foreground/80">
-              {diary.content}
+            <p className="line-clamp-4 text-sm leading-relaxed text-foreground/80">
+              <DiaryMarkdown variant="excerpt">{diary.content}</DiaryMarkdown>
             </p>
             {diary.images && diary.images.length > 0 && (
               <div className="grid grid-cols-3 items-start gap-2 pt-3 sm:grid-cols-4">

--- a/src/features/searchDiary/components/DiarySearchDialog.test.tsx
+++ b/src/features/searchDiary/components/DiarySearchDialog.test.tsx
@@ -106,6 +106,36 @@ describe("DiarySearchDialog", () => {
     ).toHaveLength(1);
   });
 
+  it("検索結果ではMarkdown記法とリンク先を除いた本文を表示する", async () => {
+    const markdownDiary = createDiary(
+      "markdown-diary",
+      new Date(),
+      "Markdown日記",
+      [],
+    );
+    markdownDiary.content =
+      "## 朝の記録\n\n[公園](https://example.com/park)を散歩した。";
+    setCachedDiaries([markdownDiary]);
+    const user = userEvent.setup();
+
+    render(<DiarySearchDialog />);
+
+    await user.type(
+      screen.getByRole("textbox", { name: "日記の検索キーワード" }),
+      "公園",
+    );
+
+    const result = await screen.findByRole("button", {
+      name: /Markdown日記/,
+    });
+    expect(result).toHaveTextContent("朝の記録");
+    expect(result).toHaveTextContent("公園");
+    expect(result).not.toHaveTextContent("##");
+    expect(result).not.toHaveTextContent("https://example.com/park");
+    expect(result.querySelector("h2")).not.toBeInTheDocument();
+    expect(result.querySelector("a")).not.toBeInTheDocument();
+  });
+
   it("直近1年にタグがなければ頻出タグ欄を表示しない", () => {
     const olderThanOneYear = new Date();
     olderThanOneYear.setFullYear(olderThanOneYear.getFullYear() - 2);

--- a/src/features/searchDiary/components/DiarySearchDialog.tsx
+++ b/src/features/searchDiary/components/DiarySearchDialog.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { DiaryMarkdown } from "@/components/shared/diary/DiaryMarkdown";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -194,7 +195,9 @@ export const DiarySearchDialog = () => {
                     </time>
                   </div>
                   <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                    {diary.content}
+                    <DiaryMarkdown variant="excerpt">
+                      {diary.content}
+                    </DiaryMarkdown>
                   </p>
                 </Button>
                 {index < visibleResults.length - 1 && (

--- a/src/features/sharedDiary/components/SharedDiaryView.test.tsx
+++ b/src/features/sharedDiary/components/SharedDiaryView.test.tsx
@@ -51,6 +51,24 @@ beforeEach(() => {
 });
 
 describe("SharedDiaryView favorite", () => {
+  it("共有日記の本文をMarkdownで表示する", () => {
+    useSharedDiaryMock.mockReturnValue({
+      diary: {
+        ...diary,
+        content: "## 海辺の記録\n\n**忘れたくない景色**だった。",
+      },
+      sharedDiaryId: "shared-diary-1",
+      isLoading: false,
+    });
+
+    render(<SharedDiaryView authenticatedUserId={null} />);
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "海辺の記録" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("忘れたくない景色").tagName).toBe("STRONG");
+  });
+
   it("未認証時はお気に入りボタンを表示しない", () => {
     render(<SharedDiaryView authenticatedUserId={null} />);
 

--- a/src/features/sharedDiary/components/SharedDiaryView.tsx
+++ b/src/features/sharedDiary/components/SharedDiaryView.tsx
@@ -1,4 +1,5 @@
 import { LoadingScreen } from "@/components/shared/common/LoadingScreen";
+import { DiaryMarkdown } from "@/components/shared/diary/DiaryMarkdown";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -96,9 +97,7 @@ export const SharedDiaryView = ({
             <CardTitle>{diary.title}</CardTitle>
           </CardHeader>
           <CardContent className="px-2">
-            <p className="whitespace-pre-wrap text-foreground/80">
-              {diary.content}
-            </p>
+            <DiaryMarkdown>{diary.content}</DiaryMarkdown>
           </CardContent>
           <CardFooter className="flex items-end gap-3 p-0">
             {diary.tags.length >= 1 && (


### PR DESCRIPTION
## 概要
- 日記本文向けの安全なMarkdown表示コンポーネントを追加
- 作成・編集画面に「入力 / プレビュー」タブを追加
- 詳細・共有画面を完全なMarkdown表示にし、一覧・検索はプレーンテキストの抜粋表示に変更
- Markdown記法を含むseedサンプル、コンポーネントテスト、UIドキュメントを追加・更新

## 検証
- `pnpm build`
- 変更ファイルのESLint
- 変更ファイルのPrettier check
- `git diff --check`
- `pnpm seed`（Emulator: 日記14件、メモリ10件）
- Playwrightによるデスクトップ・モバイル、light・dark、作成プレビュー・詳細表示の確認
- `pnpm test`: 226件中224件成功

## 既存の失敗
- `pnpm lint`: `ProfileSettingsForm.tsx` の未使用import 2件、`useMonthSelector.ts` のHooksルール違反1件
- `DiaryUnshareDialog.test.tsx`: 現行文言と期待値の不一致
- `LegalPage.test.tsx`: 現行リーガル文書と期待値の不一致

## 未確認
- 本番Firebase環境での動作（Firestore schema / Security Rulesの変更なし）